### PR TITLE
We should not need a default wait time for a click ok command.

### DIFF
--- a/lib/Test/WWW/WebKit2.pm
+++ b/lib/Test/WWW/WebKit2.pm
@@ -100,7 +100,7 @@ sub click_ok {
     $description //= '';
     local $Test::Builder::Level = $Test::Builder::Level + 1;
 
-    $timeout ||= $self->default_timeout;
+    $timeout ||= 0;
 
     my $result = eval { $self->click($locator, $timeout) };
 


### PR DESCRIPTION
The wait for a click_ok is not needed. Timeouts should be consciously added or use click_and_wait.